### PR TITLE
Small fix to normalization procedure in hh-ERPA

### DIFF
--- a/eomee/doubleionization.py
+++ b/eomee/doubleionization.py
@@ -210,16 +210,19 @@ class WrappNonlinear:
             s_cv= pick_singlets(ev_p, cv_p)[1]
             norm = np.dot(s_cv, np.dot(hh.rhs, s_cv.T))
             diag_n = np.diag(norm)
-            sqr_n = np.sqrt(diag_n)
-            c = (s_cv.T / sqr_n).T
+            idx = np.where(diag_n > 0)[0]  # Remove eigenvalues with negative norm
+            sqr_n = np.sqrt(diag_n[idx])
+            c = (s_cv[idx].T / sqr_n).T
         else:
-            s_cv= pick_singlets(ev_p, cv_p)[1]
-            norm = np.dot(s_cv, np.dot(hh.rhs, s_cv.T))
-            diag_n = np.diag(norm)
-            sqr_n = np.sqrt(diag_n)
-            s_cv = (s_cv.T / sqr_n).T
-            t_cv = pick_multiplets(ev_p, cv_p)[1]
-            c = np.append(s_cv, t_cv, axis=0)
+            raise NotImplementedError("Only singlets are implemented")
+            # s_cv= pick_singlets(ev_p, cv_p)[1]
+            # norm = np.dot(s_cv, np.dot(hh.rhs, s_cv.T))
+            # diag_n = np.diag(norm)
+            # idx = np.where(diag_n > 0)[0]
+            # sqr_n = np.sqrt(diag_n[idx])
+            # s_cv = (s_cv[idx].T / sqr_n).T
+            # t_cv = pick_multiplets(ev_p, cv_p)[1]
+            # c = np.append(s_cv, t_cv, axis=0)
         # Compute transition RDMs (eq. 32)
         rdm_terms = WrappNonlinear.eval_tdmterms(n, self.dm1)
         tv = WrappNonlinear.eval_nonlinearterms(n, self.dm1, c, rdm_terms)

--- a/eomee/spinadapted/holehole.py
+++ b/eomee/spinadapted/holehole.py
@@ -275,9 +275,9 @@ class Integrandhh:
         cv_p = pickpositiveeig(w, c)[1]
         norm = np.dot(cv_p, np.dot(metric, cv_p.T))
         diag_n = np.diag(norm)
-        # sqr_n = np.sqrt(np.abs(diag_n))
-        sqr_n = np.sqrt(diag_n)
-        c = (cv_p.T / sqr_n).T
+        idx = np.where(diag_n > 0)[0]  # Remove eigenvalues with negative norm
+        sqr_n = np.sqrt(diag_n[idx])
+        c = (cv_p[idx].T / sqr_n).T
 
         # Compute transition RDMs energy contribution (eq. 29)
         metric = metric.reshape(k, k, k, k)


### PR DESCRIPTION
Prevent incorrect states from being included in the hole-hole adiabatic connection correction by removing those with negative normalization factor during the normalization step.